### PR TITLE
36 implement plugin wallet endpoints

### DIFF
--- a/src/thyra/RequestHandler.ts
+++ b/src/thyra/RequestHandler.ts
@@ -63,6 +63,7 @@ export async function getRequest<T>(
  *
  *
  * @param url - The url to call.
+ * @param body - The body of the request.
  * @returns a Promise that resolves to an instance of JsonRpcResponseData.
  *
  */
@@ -114,6 +115,41 @@ export async function deleteRequest<T>(
       isError: true,
       result: null,
       error: new Error('Axios Error: ' + String(ex)),
+    } as JsonRpcResponseData<T>;
+  }
+
+  return {
+    isError: false,
+    result: resp.data as T,
+    error: null,
+  } as JsonRpcResponseData<T>;
+}
+
+/**
+ * This method makes a PUT request to an http rest point.
+ *
+ *
+ * @param url - The url to call.
+ * @param body - The body of the request.
+ * @returns a Promise that resolves to an instance of JsonRpcResponseData.
+ *
+ */
+export async function putRequest<T>(
+  url: string,
+  body: object,
+): Promise<JsonRpcResponseData<T>> {
+  let resp: AxiosResponse = null;
+  try {
+    resp = await axios.put<unknown, AxiosResponse, object>(
+      url,
+      body,
+      requestHeaders,
+    );
+  } catch (ex) {
+    return {
+      isError: true,
+      result: null,
+      error: new Error('Axios error: ' + String(ex)),
     } as JsonRpcResponseData<T>;
   }
 

--- a/src/thyra/ThyraProvider.ts
+++ b/src/thyra/ThyraProvider.ts
@@ -127,7 +127,7 @@ export class ThyraProvider implements IProvider {
         accountImportRequest,
       );
     } catch (ex) {
-      console.log(`Thyra accounts retrieval error`);
+      console.log(`Thyra accounts retrieval error: ${ex}`);
       throw ex;
     }
     if (thyraAccountsResponse.isError || thyraAccountsResponse.error) {
@@ -153,7 +153,7 @@ export class ThyraProvider implements IProvider {
     try {
       allAccounts = await getRequest<Array<IThyraWallet>>(THYRA_ACCOUNTS_URL);
     } catch (ex) {
-      console.error(`Thyra accounts retrieval error`);
+      console.log(`Thyra accounts retrieval error: ${ex}`);
       throw ex;
     }
     if (allAccounts.isError || allAccounts.error) {
@@ -171,13 +171,13 @@ export class ThyraProvider implements IProvider {
         `${THYRA_ACCOUNTS_URL}${accountToDelete.nickname}`,
       );
     } catch (ex) {
-      console.error(`Thyra accounts deletion error`, ex);
+      console.log(`Thyra accounts deletion error`, ex);
       return {
         response: EAccountDeletionResponse.ERROR,
       } as IAccountDeletionResponse;
     }
     if (thyraAccountsResponse.isError || thyraAccountsResponse.error) {
-      console.error(
+      console.log(
         `Thyra accounts deletion error`,
         thyraAccountsResponse.error.message,
       );

--- a/src/thyra/ThyraProvider.ts
+++ b/src/thyra/ThyraProvider.ts
@@ -22,15 +22,15 @@ import { IAccountDetails } from '../account';
 /**
  * The Thyra accounts url
  */
-export const THYRA_BASE_URL =
+export const THYRA_WALLET_URL =
   'https://my.massa/thyra/plugin/massalabs/wallet/rest/wallet/';
 
-export const THYRA_URL = 'http://my.massa';
+export const THYRA_URL = 'https://my.massa';
 
 /**
  * Thyra's url for importing accounts
  */
-export const THYRA_ACCOUNTS_URL = `${THYRA_BASE_URL}api/accounts/`;
+export const THYRA_ACCOUNTS_URL = `${THYRA_WALLET_URL}api/accounts/`;
 
 /**
  * Thyra's wallet provider name
@@ -87,7 +87,7 @@ export class ThyraProvider implements IProvider {
     let thyraAccountsResponse: JsonRpcResponseData<Array<IThyraWallet>> = null;
     try {
       thyraAccountsResponse = await getRequest<Array<IThyraWallet>>(
-        THYRA_BASE_URL,
+        THYRA_WALLET_URL,
       );
     } catch (ex) {
       console.error(`Thyra accounts retrieval error`);
@@ -123,11 +123,11 @@ export class ThyraProvider implements IProvider {
     let thyraAccountsResponse: JsonRpcResponseData<unknown> = null;
     try {
       thyraAccountsResponse = await putRequest<unknown>(
-        `${THYRA_BASE_URL}api/accounts`,
+        THYRA_ACCOUNTS_URL,
         accountImportRequest,
       );
     } catch (ex) {
-      console.error(`Thyra accounts retrieval error`);
+      console.log(`Thyra accounts retrieval error`);
       throw ex;
     }
     if (thyraAccountsResponse.isError || thyraAccountsResponse.error) {
@@ -159,7 +159,6 @@ export class ThyraProvider implements IProvider {
     if (allAccounts.isError || allAccounts.error) {
       throw allAccounts.error.message;
     }
-    console.log(`allAccounts`, allAccounts);
     // find the account with the desired address
     const accountToDelete = allAccounts.result.find(
       (account) => account.address.toLowerCase() === address.toLowerCase(),
@@ -169,7 +168,7 @@ export class ThyraProvider implements IProvider {
     let thyraAccountsResponse: JsonRpcResponseData<unknown> = null;
     try {
       thyraAccountsResponse = await deleteRequest<unknown>(
-        `${THYRA_BASE_URL}/api/accounts/${accountToDelete.nickname}`,
+        `${THYRA_ACCOUNTS_URL}${accountToDelete.nickname}`,
       );
     } catch (ex) {
       console.error(`Thyra accounts deletion error`, ex);
@@ -199,12 +198,13 @@ export class ThyraProvider implements IProvider {
   public async getNodesUrls(): Promise<string[]> {
     let nodesResponse: JsonRpcResponseData<unknown> = null;
     try {
+      console.log(`${THYRA_URL}/massa/node`);
       nodesResponse = await getRequest<unknown>(`${THYRA_URL}/massa/node`);
       if (nodesResponse.isError || nodesResponse.error) {
         throw nodesResponse.error.message;
       }
       // transform nodesResponse.result to a json and then get the "url" property
-      const nodes = JSON.parse(JSON.stringify(nodesResponse.result));
+      const nodes = nodesResponse.result as { url: string };
       return Array(nodes.url);
     } catch (ex) {
       console.error(`Thyra nodes retrieval error`, ex);
@@ -218,26 +218,6 @@ export class ThyraProvider implements IProvider {
    * @returns a Promise that resolves to the details of the newly generated account.
    */
   public async generateNewAccount(name: string): Promise<IAccountDetails> {
-    let generateNewAccountResponse: JsonRpcResponseData<IThyraWallet> = null;
-    try {
-      console.log(`generateNewAccount:`, THYRA_ACCOUNTS_URL + name);
-      generateNewAccountResponse = await postRequest<IThyraWallet>(
-        THYRA_ACCOUNTS_URL + name,
-        { name },
-      );
-    } catch (ex) {
-      console.error(`Thyra new account creation error`, ex);
-      throw ex;
-    }
-    if (
-      generateNewAccountResponse.isError ||
-      generateNewAccountResponse.error
-    ) {
-      throw generateNewAccountResponse.error.message;
-    }
-    return {
-      address: generateNewAccountResponse.result.address,
-      name: generateNewAccountResponse.result.nickname,
-    } as IAccountDetails;
+    throw 'Not implemented';
   }
 }

--- a/src/thyra/ThyraProvider.ts
+++ b/src/thyra/ThyraProvider.ts
@@ -25,6 +25,8 @@ import { IAccountDetails } from '../account';
 export const THYRA_BASE_URL =
   'https://my.massa/thyra/plugin/massalabs/wallet/rest/wallet/';
 
+export const THYRA_URL = 'http://my.massa';
+
 /**
  * Thyra's url for importing accounts
  */
@@ -197,13 +199,13 @@ export class ThyraProvider implements IProvider {
   public async getNodesUrls(): Promise<string[]> {
     let nodesResponse: JsonRpcResponseData<unknown> = null;
     try {
-      nodesResponse = await getRequest<unknown>(`${THYRA_BASE_URL}nodes`);
+      nodesResponse = await getRequest<unknown>(`${THYRA_URL}/massa/node`);
       if (nodesResponse.isError || nodesResponse.error) {
         throw nodesResponse.error.message;
       }
       // transform nodesResponse.result to a json and then get the "url" property
       const nodes = JSON.parse(JSON.stringify(nodesResponse.result));
-      return nodes.map((node: any) => node.url) as string[];
+      return Array(nodes.url);
     } catch (ex) {
       console.error(`Thyra nodes retrieval error`, ex);
       throw ex;

--- a/src/thyra/ThyraProvider.ts
+++ b/src/thyra/ThyraProvider.ts
@@ -198,7 +198,6 @@ export class ThyraProvider implements IProvider {
   public async getNodesUrls(): Promise<string[]> {
     let nodesResponse: JsonRpcResponseData<unknown> = null;
     try {
-      console.log(`${THYRA_URL}/massa/node`);
       nodesResponse = await getRequest<unknown>(`${THYRA_URL}/massa/node`);
       if (nodesResponse.isError || nodesResponse.error) {
         throw nodesResponse.error.message;

--- a/src/thyra/ThyraProvider.ts
+++ b/src/thyra/ThyraProvider.ts
@@ -1,6 +1,5 @@
 import {
   EAccountDeletionResponse,
-  IAccountDeletionRequest,
   IAccountDeletionResponse,
 } from '../provider/AccountDeletion';
 import {
@@ -14,6 +13,7 @@ import {
   deleteRequest,
   getRequest,
   postRequest,
+  putRequest,
 } from './RequestHandler';
 import { ThyraAccount } from './ThyraAccount';
 import { IAccount } from '../account/IAccount';
@@ -22,23 +22,18 @@ import { IAccountDetails } from '../account';
 /**
  * The Thyra accounts url
  */
-export const THYRA_ACCOUNTS_URL =
+export const THYRA_BASE_URL =
   'https://my.massa/thyra/plugin/massalabs/wallet/rest/wallet/';
 
 /**
  * Thyra's url for importing accounts
  */
-export const THYRA_IMPORT_ACCOUNTS_URL = `${THYRA_ACCOUNTS_URL}/api/accounts/`;
+export const THYRA_ACCOUNTS_URL = `${THYRA_BASE_URL}api/accounts/`;
 
 /**
  * Thyra's wallet provider name
  */
 export const THYRA_PROVIDER_NAME = 'THYRA';
-
-/**
- * Thyra's base url
- */
-export const THYRA_BASE_URL = 'http://my.massa/';
 
 /**
  * This interface represents the payload returned by making a call to Thyra's accounts url.
@@ -90,7 +85,7 @@ export class ThyraProvider implements IProvider {
     let thyraAccountsResponse: JsonRpcResponseData<Array<IThyraWallet>> = null;
     try {
       thyraAccountsResponse = await getRequest<Array<IThyraWallet>>(
-        THYRA_ACCOUNTS_URL,
+        THYRA_BASE_URL,
       );
     } catch (ex) {
       console.error(`Thyra accounts retrieval error`);
@@ -125,8 +120,9 @@ export class ThyraProvider implements IProvider {
     };
     let thyraAccountsResponse: JsonRpcResponseData<unknown> = null;
     try {
-      thyraAccountsResponse = await getRequest<unknown>(
-        THYRA_IMPORT_ACCOUNTS_URL,
+      thyraAccountsResponse = await putRequest<unknown>(
+        `${THYRA_BASE_URL}api/accounts`,
+        accountImportRequest,
       );
     } catch (ex) {
       console.error(`Thyra accounts retrieval error`);
@@ -161,7 +157,7 @@ export class ThyraProvider implements IProvider {
     if (allAccounts.isError || allAccounts.error) {
       throw allAccounts.error.message;
     }
-
+    console.log(`allAccounts`, allAccounts);
     // find the account with the desired address
     const accountToDelete = allAccounts.result.find(
       (account) => account.address.toLowerCase() === address.toLowerCase(),
@@ -171,7 +167,7 @@ export class ThyraProvider implements IProvider {
     let thyraAccountsResponse: JsonRpcResponseData<unknown> = null;
     try {
       thyraAccountsResponse = await deleteRequest<unknown>(
-        `${THYRA_ACCOUNTS_URL}/api/accounts/${accountToDelete.nickname}`,
+        `${THYRA_BASE_URL}/api/accounts/${accountToDelete.nickname}`,
       );
     } catch (ex) {
       console.error(`Thyra accounts deletion error`, ex);
@@ -222,8 +218,9 @@ export class ThyraProvider implements IProvider {
   public async generateNewAccount(name: string): Promise<IAccountDetails> {
     let generateNewAccountResponse: JsonRpcResponseData<IThyraWallet> = null;
     try {
+      console.log(`generateNewAccount:`, THYRA_ACCOUNTS_URL + name);
       generateNewAccountResponse = await postRequest<IThyraWallet>(
-        THYRA_ACCOUNTS_URL,
+        THYRA_ACCOUNTS_URL + name,
         { name },
       );
     } catch (ex) {

--- a/src/thyra/ThyraProvider.ts
+++ b/src/thyra/ThyraProvider.ts
@@ -218,6 +218,6 @@ export class ThyraProvider implements IProvider {
    * @returns a Promise that resolves to the details of the newly generated account.
    */
   public async generateNewAccount(name: string): Promise<IAccountDetails> {
-    throw 'Not implemented';
+    throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
- Problem for importAccount: according to the yml there are no aguments whereas we are supposed to give 2 (pubkey and privkey) -> when we call the method, a popup opens and we enter the secretkey
Should we update the wallet-provider or the thyra-plugin-wallet api ? @gregLibert 

The following methods from wallet-provider need to be added into the thyra-plugin-wallet api:
- buy_rolls
- sell_rolls
- sendTransaction


closes #36 