### PR TITLE
add callSC to IAccount

### DIFF
--- a/src/account/IAccount.ts
+++ b/src/account/IAccount.ts
@@ -1,6 +1,8 @@
 import { ITransactionDetails } from '..';
 import { IAccountBalanceResponse } from './AccountBalance';
 import { IAccountSignResponse } from './AccountSign';
+import { Args } from '@massalabs/massa-web3';
+import { NonPersistentExecution } from './INonPersistentExecution';
 
 /**
  * This interface represents an Account object.
@@ -18,4 +20,11 @@ export interface IAccount {
     recipientAddress: string,
     fee: bigint,
   ): Promise<ITransactionDetails>;
+  callSC(
+    contractAddress: string,
+    functionName: string,
+    parameter: Uint8Array | Args,
+    amount: bigint,
+    nonPersistentExecution: NonPersistentExecution,
+  );
 }


### PR DESCRIPTION
When we added callSC to the Account object, we forgot to add it in its interface. I'm just adding it