### PR TITLE
simplify the init of provider

### DIFF
--- a/src/connector/Connector.ts
+++ b/src/connector/Connector.ts
@@ -34,7 +34,7 @@ import { IAccount } from '../account/IAccount';
  * A constant string that is used to identify the HTML element that is used for
  * communication between the web page script and the content script.
  */
-const MASSA_WINDOW_OBJECT = 'massaWalletProvider';
+export const MASSA_WINDOW_OBJECT = 'massaWalletProvider';
 
 type CallbackFunction = (
   result: AllowedResponses,

--- a/src/connector/index.ts
+++ b/src/connector/index.ts
@@ -1,4 +1,9 @@
-export { connector, AllowedRequests, AllowedResponses } from './Connector';
+export {
+  connector,
+  AllowedRequests,
+  AllowedResponses,
+  MASSA_WINDOW_OBJECT,
+} from './Connector';
 export { ICustomEventMessageRequest } from './ICustomEventMessageRequest';
 export { ICustomEventMessageResponse } from './ICustomEventMessageResponse';
 export { IRegisterEvent } from './IRegisterEvent';

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export interface ITransactionDetails {
  */
 export async function providers(
   retry = true,
-  timeout = 2000,
+  timeout = 500,
 ): Promise<IProvider[]> {
   let provider: IProvider[] = [];
   while (provider.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ if (typeof window !== 'undefined') {
   window.Buffer = Buffer;
 }
 
-import { connector } from './connector/Connector';
+import { connector, MASSA_WINDOW_OBJECT } from './connector/Connector';
 import { IProvider } from './provider/IProvider';
 import { Provider } from './provider/Provider';
 import {
@@ -50,6 +50,21 @@ export function providers(): IProvider[] {
     }
   }
   return providers;
+}
+
+/**
+ * Register a provider to interact with the wallet.
+ *
+ * @param name - The name of the provider.
+ */
+export function registerProvider(name: string, id = MASSA_WINDOW_OBJECT): void {
+  const registerEvent = new CustomEvent('register', {
+    detail: { providerName: name },
+  });
+  const element = document.getElementById(id);
+  if (element) {
+    element.dispatchEvent(registerEvent);
+  }
 }
 
 export { AllowedRequests, AllowedResponses } from './connector';

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,24 +38,43 @@ export interface ITransactionDetails {
   operationId: string;
 }
 
-export function providers(): IProvider[] {
-  let providers: IProvider[] = [];
-  for (const providerName of Object.keys(connector.getWalletProviders())) {
-    if (providerName === MASSA_STATION_PROVIDER_NAME) {
-      const p = new MassaStationProvider();
-      providers.push(p);
-    } else {
-      const p = new Provider(providerName);
-      providers.push(p);
+/**
+ * Get the list of providers that are available to interact with.
+ *
+ * @param retry - If true, will retry to get the list of providers if none are available.
+ * @param timeout - The timeout in milliseconds to wait between retries. default is 2000ms.
+ *
+ * @returns An array of providers.
+ */
+export async function providers(
+  retry = true,
+  timeout = 2000,
+): Promise<IProvider[]> {
+  let provider: IProvider[] = [];
+  while (provider.length === 0) {
+    for (const providerName of Object.keys(connector.getWalletProviders())) {
+      if (providerName === MASSA_STATION_PROVIDER_NAME) {
+        const p = new MassaStationProvider();
+        provider.push(p);
+      } else {
+        const p = new Provider(providerName);
+        provider.push(p);
+      }
+    }
+    // If no providers are available, wait and try again
+    if (retry && provider.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, timeout));
     }
   }
-  return providers;
+
+  return provider;
 }
 
 /**
- * Register a provider to interact with the wallet.
+ * Manually register a provider to interact with.
  *
  * @param name - The name of the provider.
+ * @param id - The id of the HTML element that is used to communicate with the provider.
  */
 export function registerProvider(name: string, id = MASSA_WINDOW_OBJECT): void {
   const registerEvent = new CustomEvent('register', {

--- a/test/dapp/index.html
+++ b/test/dapp/index.html
@@ -24,20 +24,14 @@
   
       console.log("[DAPP_HTML] Hello from Dapp! ");
       
-      let providers = window.wallet.providers();
-      console.log("[DAPP_HTML] Discovered Providers count", providers.length);
-      console.log("[DAPP_HTML] Discovered providers ...", providers);
+      let providers = await window.wallet.providers();
 
-      // wait for a few secs for the provider to be discovered
-      await delay(3000);
-
-      providers = window.wallet.providers();
       console.log("[DAPP_HTML] Discovered Providers count", providers.length);
       console.log("[DAPP_HTML] Discovered providers ...", providers);
 
       // get a provider (not MASSASTATION)
       const myProvider = providers.find((p) => p.name() !== "MASSASTATION");
-      console.log("[DAPP_HTML] Provider Name", myProvider.name());
+      console.log("[DAPP_HTML] Provider Name", myProvider);
 
       // import an account
       console.log("[DAPP_HTML] Importing an account ...");


### PR DESCRIPTION
As a dev using the wallet provider, this is the good way to initialize a provider: 
```typescript
import {
    providers,
} from "@massalabs/wallet-provider";

const provider = providers(); // -> the providers
```

then, we can recover the accounts like this:
```typescript
const accounts: IAccount[] = provider.accounts();
```
**Remark:** 
The content of `accounts` is the same no matter the provider you are using (station or any other provider)









closes #76 