### PR TITLE
Patch for BearbyAccount.ts to support bigint values

### DIFF
--- a/src/bearbyWallet/BearbyAccount.ts
+++ b/src/bearbyWallet/BearbyAccount.ts
@@ -199,22 +199,25 @@ export class BearbyAccount implements IAccount {
 
     if (parameter instanceof Uint8Array) {
       throw new Error(
-        'Bearby wallet does not support Uint8Array as parameter. Please use Args instead',
+        `Bearby wallet does not support Uint8Array as a parameter. 
+        Please use Args instead.`,
       );
     }
-    // setup the params from Args
+
     let params: CallParam[] = [];
     try {
       params = parameter.getArgsList().map((arg) => {
-        return {
-          type: arg.type,
-          value: arg.value,
-        } as CallParam;
+        // Convert bigint values to strings to ensure compatibility with bearbyJs
+        if (typeof arg.value === 'bigint') {
+          arg.value = arg.value.toString();
+        }
+        return arg as CallParam;
       });
     } catch (ex) {
-      throw new Error(`
-      Bearby wallet does not support Uint8Array, serializable, and serializableObjectArray. 
-      To use them switch to MassaStation`);
+      throw new Error(
+        `Bearby wallet encountered an error while processing the parameter. 
+         To use Uint8Array, serializable, and serializableObjectArray, switch to MassaStation.`,
+      );
     }
 
     const operationId = await web3.contract.call({


### PR DESCRIPTION
There is an issue with bearbyJs when trying to use bigint as value in parameters.

![Screenshot 2023-09-04 at 16 29 53](https://github.com/massalabs/wallet-provider/assets/44082144/71cd9114-d21c-4dfd-9e08-e7fffe0c8f24)

However, according to the interface, it should accept them.

From bearbyjs code 
```typescript
export interface CallParam {
  type: ArgTypes;
  vname?: string;
  // value can be a bigint
  value: string | bigint | number | boolean;
}

export interface CallSmartContractParams {
  fee: number;
  maxGas: number;
  coins: number;
  targetAddress: string;
  functionName: string;
  parameters: CallParam[];
}
```

To unlock ICO Quest projects, I propose this quick fix