### PR TITLE
fix bearby not detected

### DIFF
--- a/src/providersManager/ProvidersListener.ts
+++ b/src/providersManager/ProvidersListener.ts
@@ -1,5 +1,5 @@
 import { IProvider } from '../provider/IProvider';
-import { providers } from './providers';
+import { getProvidersInstances, providers } from './providers';
 
 export class ProvidersListener {
   private intervalDelay: number;
@@ -14,7 +14,7 @@ export class ProvidersListener {
     callback: (providers: IProvider[]) => void,
   ): Promise<void> {
     try {
-      const newProviders = await providers();
+      const newProviders = await getProvidersInstances();
       if (this.hasProvidersChanged(newProviders)) {
         this.currentProviders = newProviders;
         callback(newProviders);

--- a/src/providersManager/providers.ts
+++ b/src/providersManager/providers.ts
@@ -2,8 +2,15 @@ import { Provider } from '../provider/Provider';
 import { connector } from '../connector/Connector';
 import { providerList } from './providerList';
 import { IProvider } from 'src/provider/IProvider';
+import { wait } from '../utils/time';
 
 export async function providers(): Promise<IProvider[]> {
+  // Wait for providers to be initialized
+  await wait(200);
+  return getProvidersInstances();
+}
+
+export async function getProvidersInstances(): Promise<IProvider[]> {
   const providerInstances: IProvider[] = [];
 
   for (const provider of providerList) {


### PR DESCRIPTION
I created a new function getProvidersInstances because we don't want to wait 200ms every time in the provider listener