### PR TITLE
Fix Bearby chainId typing

### DIFF
--- a/src/bearbyWallet/utils/network.ts
+++ b/src/bearbyWallet/utils/network.ts
@@ -10,7 +10,7 @@ export const networkInfos = async (): Promise<Network> => {
   }
   return {
     name: net,
-    chainId: res.result.chain_id,
+    chainId: BigInt(res.result.chain_id),
     minimalFee: Mas.fromString(res.result.minimal_fees),
   };
 };


### PR DESCRIPTION
fixes a bug where the networkInfos.chainId from bearby doesn't match the Bigint typing of buildnet chain ID
// Here chainId is bearby's network chain ID
<img width="464" alt="Screenshot 2025-02-13 at 10 51 22" src="https://github.com/user-attachments/assets/24dcc5fc-354c-4621-9f95-1f105093fdd0" />
